### PR TITLE
fix(windows): add double quotes for executables path

### DIFF
--- a/tasks/options/shell.js
+++ b/tasks/options/shell.js
@@ -6,12 +6,12 @@ module.exports = {
     options: {
       stdout: true
     },
-    command: './node_modules/.bin/yaml2json fixtures --recursive --save'
+    command: '"./node_modules/.bin/yaml2json" fixtures --recursive --save'
   },
   data: {
     options: {
       stdout: true
     },
-    command: './node_modules/.bin/yaml2json data --recursive --save'
+    command: '"./node_modules/.bin/yaml2json" data --recursive --save'
   }
 };


### PR DESCRIPTION
Add double quotes around executables path to make grunt works for windows.
